### PR TITLE
Removing the database seed with sample data.

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,4 +1,2 @@
 #!/bin/sh
-#gradle assemble
-#docker build -t lidar-indexer .
 gradle jibDockerBuild

--- a/build.gradle
+++ b/build.gradle
@@ -84,4 +84,5 @@ tasks.withType(JavaExec) {
 }
 
 jib.to.image = 'nexus-docker-public-hosted.ossim.io/lidar-indexer'
-//jib.to.image = 'hercules/lidar-indexer'
+jib.container.creationTime = 'USE_CURRENT_TIMESTAMP'
+

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 #docker run -it --rm -p 8080:8080 -e PGHOST=host.docker.internal lidar-indexer
-docker run -it --rm -p 8080:8080 -e PGHOST=host.docker.internal hercules/lidar-indexer
+docker run -it --rm -p 8080:8080 -e PGHOST=host.docker.internal nexus-docker-public-hosted.ossim.io/lidar-indexer:latest

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,6 @@ metadata:
 build:
   artifacts:
     - image: nexus-docker-public-hosted.ossim.io/lidar-indexer
-#    - image: hercules/lidar-indexer
       jib: {}
 deploy:
   helm:

--- a/src/main/resources/db/liquibase-changelog.groovy
+++ b/src/main/resources/db/liquibase-changelog.groovy
@@ -3,5 +3,6 @@ package db
 databaseChangeLog {
     include file: 'changelog/migrations.installPostgis.groovy', relativeToChangelogFile: true
     include file: 'changelog/migrations.initialSchema.groovy', relativeToChangelogFile: true
-    include file: 'changelog/migrations.loadSampleData.groovy', relativeToChangelogFile: true
+    // Uncomment the line below to seed the database with test data
+    // include file: 'changelog/migrations.loadSampleData.groovy', relativeToChangelogFile: true
 }


### PR DESCRIPTION
This PR removed the liquibase sample database seed; however, it was only commented out in case the data is need while debugging the application in a stand alone env.  

In addition, there were a couple of other some mods to the build.gradle file to add the 'creationTime' attribute to the Docker jib build.  Previously, the jib builds were not properly stamping the docker images, and there dates were showing build 50 years ago.

I also modified the name of the docker image that is produced.