### PR TITLE
Adding 'Status' to lidar product schema and class

### DIFF
--- a/src/main/groovy/lidar/indexer/LidarProduct.groovy
+++ b/src/main/groovy/lidar/indexer/LidarProduct.groovy
@@ -21,11 +21,9 @@ class LidarProduct {
 
     Date ingest_date
 
-    //String bbox // This is nullable in db, so we will come back to it later
-
     String keyword
 
-    String s3_link = "https://starwars.s3.amazonaws.com/characters/leia.txt"
+    String s3_link
 
     String status
 

--- a/src/main/groovy/lidar/indexer/LidarProduct.groovy
+++ b/src/main/groovy/lidar/indexer/LidarProduct.groovy
@@ -27,6 +27,8 @@ class LidarProduct {
 
     String s3_link = "https://starwars.s3.amazonaws.com/characters/leia.txt"
 
+    String status
+
     @JsonSerialize(using = WktGeometrySerializer)
     @JsonDeserialize(using = WktGeometryDeserializer)
     @Column(columnDefinition = 'geometry(Polygon, 4326)')

--- a/src/main/resources/db/changelog/migrations.initialSchema.groovy
+++ b/src/main/resources/db/changelog/migrations.initialSchema.groovy
@@ -1,7 +1,7 @@
 package db.migrations
 
 databaseChangeLog {
-    changeSet(author: "teamhercules", id: "20") {
+    changeSet(author: "team_chimera", id: "20") {
 
         comment('Create intial table and schema')
         createTable(tableName: "lidar_products") {
@@ -23,6 +23,10 @@ databaseChangeLog {
             }
 
             column(name: "s3_link", type: "VARCHAR(255)") {
+                constraints(nullable: "true", unique: "false")
+            }
+
+            column(name: "status", type: "VARCHAR(255)") {
                 constraints(nullable: "true", unique: "false")
             }
 


### PR DESCRIPTION
This PR adds a new 'status' column to the lidar_db schema.  It will be used to hold the conversion status progress during the lidar-converter-server's processing activity. 