### PR TITLE
Added 'type' column to schema

### DIFF
--- a/src/main/groovy/lidar/indexer/LidarProduct.groovy
+++ b/src/main/groovy/lidar/indexer/LidarProduct.groovy
@@ -27,6 +27,8 @@ class LidarProduct {
 
     String status
 
+    String type
+
     @JsonSerialize(using = WktGeometrySerializer)
     @JsonDeserialize(using = WktGeometryDeserializer)
     @Column(columnDefinition = 'geometry(Polygon, 4326)')

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,7 @@ micronaut:
     server:
         cors:
             enabled: true
+        port: 8888
 
 ---
 #micronaut:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,6 @@ micronaut:
     server:
         cors:
             enabled: true
-        port: 8888
 
 ---
 #micronaut:

--- a/src/main/resources/db/changelog/migrations.initialSchema.groovy
+++ b/src/main/resources/db/changelog/migrations.initialSchema.groovy
@@ -26,6 +26,10 @@ databaseChangeLog {
                 constraints(nullable: "true", unique: "false")
             }
 
+            column(name: "type", type: "VARCHAR(255)") {
+                constraints(nullable: "true", unique: "false")
+            }
+
             column(name: "status", type: "VARCHAR(255)") {
                 constraints(nullable: "true", unique: "false")
             }


### PR DESCRIPTION
This PR adds a 'type' column to the database schema.  It will be used to differentiate between the different conversion types: Entwine v. Potree