### PR TITLE
Added status tracking functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id "application"
 }
 
-version "0.2"
+version "0.3"
 group "lidar.indexer"
 
 repositories {

--- a/src/main/groovy/lidar/indexer/LidarProductController.groovy
+++ b/src/main/groovy/lidar/indexer/LidarProductController.groovy
@@ -53,21 +53,10 @@ class LidarProductController {
 
         // Do a findById to get the record we want to update
         Optional<LidarProduct> result = lidarProductRepository.findById(id)
-        println "-"*40
-        println "result: ${result}"
-        println "-"*40
         if (result.isPresent()){
-            println "In the if check..." + lidarProduct.properties
+
             LidarProduct current = result.get()
             lidarProduct.id = current.id
-
-            println "-"*40
-            println "current: ${current.properties}"
-            println "-"*40
-
-            // May need an if check here to see if the properties of the
-            // incoming lidarProduct are null.  If they are we need
-            // to use the 'current' one
             lidarProduct.ingest_date = current.ingest_date
 
             lidarProductRepository.update(lidarProduct)

--- a/src/main/groovy/lidar/indexer/LidarProductController.groovy
+++ b/src/main/groovy/lidar/indexer/LidarProductController.groovy
@@ -1,6 +1,7 @@
 package lidar.indexer
 
 import groovy.transform.CompileStatic
+import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
@@ -23,10 +24,11 @@ class LidarProductController {
 
     // CREATE
     @Post("/createLidarProduct")
-    HttpStatus createLidarProduct(@Body @Valid LidarProduct lidarProduct) {
+    HttpResponse<LidarProduct> createLidarProduct(@Body @Valid LidarProduct lidarProduct) {
 
-        lidarProductRepository.save(lidarProduct)
-        return HttpStatus.OK
+        def savedRecord = lidarProductRepository.save(lidarProduct)
+        println savedRecord.id
+        return HttpResponse.ok(savedRecord) // returns json of object that was saved
     }
 
     // READ
@@ -51,9 +53,17 @@ class LidarProductController {
 
         // Do a findById to get the record we want to update
         Optional<LidarProduct> result = lidarProductRepository.findById(id)
+        println "-"*40
+        println "result: ${result}"
+        println "-"*40
         if (result.isPresent()){
+            println "In the if check..." + lidarProduct.properties
             LidarProduct current = result.get()
             lidarProduct.id = current.id
+
+            println "-"*40
+            println "current: ${current.properties}"
+            println "-"*40
 
             // May need an if check here to see if the properties of the
             // incoming lidarProduct are null.  If they are we need


### PR DESCRIPTION
This PR modifies the lidar-indexer so that it can help track the state of the conversion process of the lidar data.  The createLidarProduct endpoint was modified to return an HTTPResponse so that the converter can use it in the state changes